### PR TITLE
Estruturando os repositorios seguindo Clean Architecture

### DIFF
--- a/src/main/java/io/github/clean_arquiteture/application/repositories/ConsultaRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/application/repositories/ConsultaRepository.java
@@ -1,0 +1,10 @@
+package io.github.clean_arquiteture.application.repositories;
+
+import io.github.clean_arquiteture.infrastructure.persistence.entities.ConsultaEntity;
+
+import java.util.Optional;
+
+public interface ConsultaRepository {
+    Optional<ConsultaEntity> findById(Long id);
+    ConsultaEntity save(ConsultaEntity consulta);
+}

--- a/src/main/java/io/github/clean_arquiteture/application/repositories/MedicoRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/application/repositories/MedicoRepository.java
@@ -1,0 +1,10 @@
+package io.github.clean_arquiteture.application.repositories;
+
+import io.github.clean_arquiteture.infrastructure.persistence.entities.MedicoEntity;
+
+import java.util.Optional;
+
+public interface MedicoRepository {
+    Optional<MedicoEntity> findById(Long id);
+    MedicoEntity save(MedicoEntity medico);
+}

--- a/src/main/java/io/github/clean_arquiteture/application/repositories/PacienteRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/application/repositories/PacienteRepository.java
@@ -1,0 +1,10 @@
+package io.github.clean_arquiteture.application.repositories;
+
+import io.github.clean_arquiteture.infrastructure.persistence.entities.PacienteEntity;
+
+import java.util.Optional;
+
+public interface PacienteRepository {
+    Optional<PacienteEntity> findById(Long id);
+    PacienteEntity save(PacienteEntity paciente);
+}

--- a/src/main/java/io/github/clean_arquiteture/application/repositories/UsuarioRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/application/repositories/UsuarioRepository.java
@@ -1,0 +1,10 @@
+package io.github.clean_arquiteture.application.repositories;
+
+import io.github.clean_arquiteture.infrastructure.persistence.entities.UsuarioEntity;
+
+import java.util.Optional;
+
+public interface UsuarioRepository{
+    Optional<UsuarioEntity> findById(Long id);
+    UsuarioEntity save(UsuarioEntity usuario);
+}

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/ConsultaEntity.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/ConsultaEntity.java
@@ -1,4 +1,4 @@
-package io.github.clean_arquiteture.infrastructure.persistence;
+package io.github.clean_arquiteture.infrastructure.persistence.entities;
 
 import java.time.OffsetDateTime;
 

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/MedicoEntity.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/MedicoEntity.java
@@ -1,4 +1,4 @@
-package io.github.clean_arquiteture.infrastructure.persistence;
+package io.github.clean_arquiteture.infrastructure.persistence.entities;
 
 import java.util.List;
 

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/PacienteEntity.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/PacienteEntity.java
@@ -1,4 +1,4 @@
-package io.github.clean_arquiteture.infrastructure.persistence;
+package io.github.clean_arquiteture.infrastructure.persistence.entities;
 
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/UsuarioEntity.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/entities/UsuarioEntity.java
@@ -1,4 +1,4 @@
-package io.github.clean_arquiteture.infrastructure.persistence;
+package io.github.clean_arquiteture.infrastructure.persistence.entities;
 
 import io.github.clean_arquiteture.infrastructure.enumerate.PerfilEnum;
 import jakarta.persistence.Column;

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/ConsultaJpaRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/ConsultaJpaRepository.java
@@ -1,0 +1,8 @@
+package io.github.clean_arquiteture.infrastructure.persistence.repositories;
+
+import io.github.clean_arquiteture.application.repositories.ConsultaRepository;
+import io.github.clean_arquiteture.infrastructure.persistence.entities.ConsultaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsultaJpaRepository extends JpaRepository<ConsultaEntity, Long>, ConsultaRepository {
+}

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/MedicoJpaRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/MedicoJpaRepository.java
@@ -1,0 +1,8 @@
+package io.github.clean_arquiteture.infrastructure.persistence.repositories;
+
+import io.github.clean_arquiteture.application.repositories.MedicoRepository;
+import io.github.clean_arquiteture.infrastructure.persistence.entities.MedicoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MedicoJpaRepository extends JpaRepository<MedicoEntity, Long>, MedicoRepository {
+}

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/PacienteJpaRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/PacienteJpaRepository.java
@@ -1,0 +1,8 @@
+package io.github.clean_arquiteture.infrastructure.persistence.repositories;
+
+import io.github.clean_arquiteture.application.repositories.PacienteRepository;
+import io.github.clean_arquiteture.infrastructure.persistence.entities.PacienteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PacienteJpaRepository extends JpaRepository<PacienteEntity, Long>, PacienteRepository {
+}

--- a/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/UsuarioJpaRepository.java
+++ b/src/main/java/io/github/clean_arquiteture/infrastructure/persistence/repositories/UsuarioJpaRepository.java
@@ -1,0 +1,10 @@
+package io.github.clean_arquiteture.infrastructure.persistence.repositories;
+
+import io.github.clean_arquiteture.application.repositories.UsuarioRepository;
+import io.github.clean_arquiteture.infrastructure.persistence.entities.UsuarioEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsuarioJpaRepository extends JpaRepository<UsuarioEntity, Long>, UsuarioRepository {
+}


### PR DESCRIPTION
Este PR implementa a separação da camada de repositórios conforme o Clean Architecture. Agora, por exemplo, a interface UsuarioRepository está na camada application, enquanto a implementação concreta UsuarioJpaRepository usa JpaRepository na camada infrastructure.

- Criada as interfaces dos respositorios na camada application.repositories
- Criado as interfaces extendendo JpaRepository na camada infrastructure.persistence.repositories
- Melhorada separação entre application e infrastructure garantindo desacoplamento